### PR TITLE
Implement SchedulePage(상영일정 페이지)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "^7.5.3"
+        "react-router-dom": "^7.5.3",
+        "zustand": "^5.0.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -1398,7 +1399,7 @@
       "version": "19.1.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1890,7 +1891,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -3386,6 +3387,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.4.tgz",
+      "integrity": "sha512-39VFTN5InDtMd28ZhjLyuTnlytDr9HfwO512Ai4I8ZABCoyAj4F1+sr7sD1jP/+p7k77Iko0Pb5NhgBFDCX0kQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.5.3"
+    "react-router-dom": "^7.5.3",
+    "zustand": "^5.0.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/src/assets/cinema_info/mock_cinema.json
+++ b/src/assets/cinema_info/mock_cinema.json
@@ -1,0 +1,92 @@
+[
+  {
+    "movieName": "거룩한 밤: 데몬 헌텃스 1",
+    "rating": 26.7,
+    "star": 8,
+    "image": "/src/assets/movie1.jpg",
+    "grade": "/src/assets/grade_15.png",
+    "isReservable": true,
+    "rank": 1
+  },
+  {
+    "movieName": "거룩한 밤: 데몬 헌텃스 2",
+    "rating": 25.7,
+    "star": 7.8,
+    "image": "/src/assets/movie1.jpg",
+    "grade": "/src/assets/grade_19.png",
+    "isReservable": true,
+    "rank": 2
+  },
+  {
+    "movieName": "거룩한 밤: 데몬 헌텃스 3",
+    "rating": 24.7,
+    "star": 7.4,
+    "image": "/src/assets/movie1.jpg",
+    "grade": "/src/assets/grade_15.png",
+    "isReservable": true,
+    "rank": 3
+  },
+  {
+    "movieName": "거룩한 밤: 데몬 헌텃스 4",
+    "rating": 23.7,
+    "star": 5.5,
+    "image": "/src/assets/movie1.jpg",
+    "grade": "/src/assets/grade_19.png",
+    "isReservable": true,
+    "rank": 4
+  },
+  {
+    "movieName": "거룩한 밤: 데몬 헌텃스 5",
+    "rating": 22.7,
+    "star": 6.9,
+    "image": "/src/assets/movie1.jpg",
+    "grade": "/src/assets/grade_19.png",
+    "isReservable": true,
+    "rank": 5
+  },
+  {
+    "movieName": "거룩한 밤: 데몬 헌텃스 6",
+    "rating": 21.7,
+    "star": 8,
+    "image": "/src/assets/movie1.jpg",
+    "grade": "/src/assets/grade_15.png",
+    "isReservable": true,
+    "rank": 6
+  },
+  {
+    "movieName": "거룩한 밤: 데몬 헌텃스 7",
+    "rating": 20.7,
+    "star": 9,
+    "image": "/src/assets/movie1.jpg",
+    "grade": "/src/assets/grade_19.png",
+    "isReservable": true,
+    "rank": 7
+  },
+  {
+    "movieName": "거룩한 밤: 데몬 헌텃스 8",
+    "rating": 19.7,
+    "star": null,
+    "image": "/src/assets/movie1.jpg",
+    "grade": "/src/assets/grade_15.png",
+    "isReservable": false,
+    "rank": null
+  },
+  {
+    "movieName": "거룩한 밤: 데몬 헌텃스 9",
+    "rating": 20.4,
+    "star": 7.2,
+    "image": "/src/assets/movie1.jpg",
+    "grade": "/src/assets/grade_19.png",
+    "isReservable": true,
+    "rank": null
+  },
+  {
+    "movieName": "거룩한 밤: 데몬 헌텃스 10",
+    "rating": 21.4,
+    "star": null,
+    "image": "/src/assets/movie1.jpg",
+    "grade": "/src/assets/grade_15.png",
+    "isReservable": false,
+    "rank": null
+  }
+]

--- a/src/assets/schedule/mock_schedule.json
+++ b/src/assets/schedule/mock_schedule.json
@@ -1,0 +1,126 @@
+[
+  {
+    "date": "2025-05-17",
+    "schedules": [
+      {
+        "movieName": "Inception",
+        "durationMinutes": 148,
+        "grade": "/src/assets/grade_15.png",
+        "theaters": [
+          {
+            "theaterId": "A",
+            "theaterName": "Theater 1",
+            "format": "2D",
+            "subDub": "더빙",
+            "availSeat": 32,
+            "totalSeat": 60,
+            "startTimes": ["08:00", "10:30", "13:00", "15:30", "18:00", "20:30", "23:00", "01:30", "04:00", "06:30", "08:30"],
+            "endTimes": ["10:28", "12:58", "15:28", "17:58", "20:28", "22:58", "01:28", "03:58", "06:28", "08:58", "10:58"]
+          },
+          {
+            "theaterId": "B",
+            "theaterName": "Theater 2",
+            "format": "IMAX",
+            "subDub": "자막",
+            "availSeat": 68,
+            "totalSeat": 90,
+            "startTimes": ["11:00", "14:30", "18:00", "21:30"],
+            "endTimes": ["13:28", "16:58", "20:28", "23:58"]
+          }
+        ]
+      },
+      {
+        "movieId": 2,
+        "movieName": "The Matrix",
+        "durationMinutes": 136,
+        "grade": "/src/assets/grade_19.png",
+        "theaters": [
+          {
+            "theaterId": "A",
+            "theaterName": "Theater 1",
+            "format": "3D",
+            "subDub": "자막",
+            "availSeat": 123,
+            "totalSeat": 156,
+            "startTimes": ["09:30", "12:30", "15:45", "19:00"],
+            "endTimes": ["11:46", "14:46", "17:61", "21:16"]
+          }
+        ]
+      }
+  ]
+  },
+  {
+    "date": "2025-05-18",
+    "schedules": [
+      {
+        "movieId": 3,
+        "movieName": "Toy Story",
+        "durationMinutes": 81,
+        "grade": "/src/assets/grade_15.png",
+        "theaters": [
+          {
+            "theaterId": "C",
+            "theaterName": "Kids Theater",
+            "format": "IMAX",
+            "subDub": "자막",
+            "availSeat": 42,
+            "totalSeat": 60,
+            "startTimes": ["10:00", "12:00", "14:00", "16:00"],
+            "endTimes": ["11:21", "13:21", "15:21", "17:21"]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "date": "2025-05-19",
+    "schedules": [
+      {
+        "movieId": 4,
+        "movieName": "거룩한 밤: 데몬 헌텃스 1",
+        "durationMinutes": 81,
+        "grade": "/src/assets/grade_15.png",
+        "theaters": [
+          {
+            "theaterId": "D",
+            "theaterName": "Theater 1",
+            "format": "2D",
+            "subDub": "자막",
+            "availSeat": 42,
+            "totalSeat": 60,
+            "startTimes": ["10:00", "12:00", "14:00", "16:00"],
+            "endTimes": ["11:21", "13:21", "15:21", "17:21"]
+          },
+          {
+            "theaterId": "E",
+            "theaterName": "Theater 4",
+            "format": "2D",
+            "subDub": null,
+            "availSeat": 42,
+            "totalSeat": 60,
+            "startTimes": ["10:00", "12:00", "14:00", "16:00"],
+            "endTimes": ["11:21", "13:21", "15:21", "17:21"]
+          }
+        ]
+      },
+      {
+        "movieId": 5,
+        "movieName": "거룩한 밤: 데몬 헌텃스 2",
+        "durationMinutes": 81,
+        "grade": "/src/assets/grade_15.png",
+        "theaters": [
+          {
+            "theaterId": "F",
+            "theaterName": "Theater 5",
+            "format": "2D",
+            "subDub": null,
+            "availSeat": 42,
+            "totalSeat": 60,
+            "startTimes": ["10:00", "12:00", "14:00", "16:00"],
+            "endTimes": ["11:21", "13:21", "15:21", "17:21"]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/src/assets/theater_info/mock_theater.json
+++ b/src/assets/theater_info/mock_theater.json
@@ -1,0 +1,122 @@
+[
+  {
+    "theaterId": "A",
+    "theaterName": "Theater 1",
+    "availSeat": 32,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "B",
+    "theaterName": "Theater 2",
+    "availSeat": 45,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "C",
+    "theaterName": "Kids Theater",
+    "availSeat": 18,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "D",
+    "theaterName": "Theater 4",
+    "availSeat": 50,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "E",
+    "theaterName": "Theater 5",
+    "availSeat": 12,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "F",
+    "theaterName": "Theater 6",
+    "availSeat": 60,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "G",
+    "theaterName": "Theater 7",
+    "availSeat": 0,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "H",
+    "theaterName": "Theater 8",
+    "availSeat": 27,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "I",
+    "theaterName": "Theater 9",
+    "availSeat": 38,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "J",
+    "theaterName": "Theater 10",
+    "availSeat": 5,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "K",
+    "theaterName": "Theater 11",
+    "availSeat": 40,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "L",
+    "theaterName": "Theater 12",
+    "availSeat": 22,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "M",
+    "theaterName": "Theater 13",
+    "availSeat": 11,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "N",
+    "theaterName": "Theater 14",
+    "availSeat": 59,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "O",
+    "theaterName": "Theater 15",
+    "availSeat": 7,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "P",
+    "theaterName": "Theater 16",
+    "availSeat": 33,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "Q",
+    "theaterName": "Theater 17",
+    "availSeat": 20,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "R",
+    "theaterName": "Theater 18",
+    "availSeat": 6,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "S",
+    "theaterName": "Theater 19",
+    "availSeat": 48,
+    "totalSeat": 60
+  },
+  {
+    "theaterId": "T",
+    "theaterName": "Theater 20",
+    "availSeat": 14,
+    "totalSeat": 60
+  }
+]

--- a/src/components/DateSlider.css
+++ b/src/components/DateSlider.css
@@ -1,0 +1,101 @@
+.time-slider-wrapper {
+  position: relative;
+  border-bottom: 1px solid darkgray;
+
+  .time-slider {
+    scroll-behavior: smooth;
+    max-width: 100%;
+    overflow: auto;
+    margin: 0 32px;
+
+    .date-area-wrapper {
+      display: flex;
+      width: max-content;
+      align-items: center;
+      user-select: none;
+
+      .date-area {
+        position: relative;
+        cursor: pointer;
+
+        .month {
+          position: absolute;
+          top: 0;
+          left: 0;
+          font-size: 12px;
+          width: 100%;
+          text-align: center;
+          font-weight: bold;
+        }
+        .main-date {
+          margin: 16px;
+          margin-top: 24px;
+
+          .date,
+          .day {
+            display: grid;
+            justify-content: center;
+            align-items: center;
+            font-size: 16px;
+          }
+          .day {
+            width: 32px;
+            aspect-ratio: 1;
+            line-height: 32px;
+            border-radius: 50%;
+            font-size: 20px;
+            font-weight: 600;
+          }
+        }
+      }
+    }
+    .date-arrows-area {
+      .left-arrow,
+      .right-arrow {
+        position: absolute;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-size: 40px;
+        background-color: rgb(212, 212, 212);
+        width: 28px;
+        height: 28px;
+        padding-bottom: 10px;
+        border-radius: 50%;
+        opacity: 0.7;
+        cursor: pointer;
+        transition: 0.3s;
+      }
+      .left-arrow {
+        top: 50%;
+        left: 2px;
+        transform: translateY(-50%);
+        z-index: 3;
+      }
+      .right-arrow {
+        top: 50%;
+        right: 2px;
+        transform: translateY(-50%);
+        z-index: 3;
+      }
+      .left-arrow:hover,
+      .right-arrow:hover {
+        opacity: 1;
+      }
+    }
+  }
+}
+
+.time-slider::-webkit-scrollbar {
+  display: none;
+}
+.choose-date {
+  background-color: black;
+  color: white;
+}
+.date-choose-sat {
+  color: rgb(29, 89, 208);
+}
+.date-choose-sun {
+  color: rgb(217, 53, 38);
+}

--- a/src/components/DateSlider.tsx
+++ b/src/components/DateSlider.tsx
@@ -1,0 +1,93 @@
+import React, { useRef, useState } from "react";
+import "./DateSlider.css";
+import { useScheduleRelatedStore } from "../stores/ScheduleRelatedStore";
+import { mockDateList } from "../utils/scheduleRelatedUtils";
+
+const DateSlider: React.FC = () => {
+  const sliderRef = useRef<HTMLDivElement>(null);
+  const [chosenDateIndex, setChosenDateIndex] = useState<number | null>(null);
+  const { setSelectedDate } = useScheduleRelatedStore();
+  // const dates = getDaysWithWeekday(40); //will use later when fetch real api
+  //mock dateList
+
+  function handleNext() {
+    const slider = sliderRef.current;
+    if (!slider) return;
+
+    const widthItem = slider.querySelector(".date-area")?.clientWidth || 0;
+    //check if we are at the end, 12 in below is margin
+    if (slider.scrollLeft + slider.clientWidth >= slider.scrollWidth - 12) {
+      //if at the end, go to the first item in the slider
+      slider.scrollLeft = 0;
+    } else {
+      slider.scrollLeft += widthItem + 64 * 6; //64px is margin
+    }
+  }
+
+  function handlePrev() {
+    const slider = sliderRef.current;
+    if (!slider) return;
+
+    const widthItem = slider.querySelector(".date-area")?.clientWidth || 0;
+    const totalItems = slider.querySelectorAll(".date-area").length;
+    //check if we are at the start
+    if (slider.scrollLeft <= 20) {
+      //if at the start, go to the last item in the slider ; 20: because sometimes there’s a slight margin.
+      slider.scrollLeft = (widthItem + 64) * (totalItems - 1); //jump to the last item, 64 is margin
+    } else {
+      slider.scrollLeft -= widthItem + 64 * 6; //64px is margin, 7: 7 days
+    }
+  }
+
+  return (
+    <div className="time-slider-wrapper">
+      <div className="time-slider" ref={sliderRef}>
+        <div className="date-area-wrapper">
+          {/* will use below line later with real api */}
+          {/* {dates.map((dateInfo, index) => ( */}
+          {mockDateList.map((dateInfo, index) => (
+            <div className="date-area" key={index}>
+              {(index == 0 || dateInfo.day == 1) && (
+                <div className="month">{dateInfo.month}월</div>
+              )}
+              <div
+                className={`main-date ${
+                  dateInfo.weekday == "토"
+                    ? "date-choose-sat"
+                    : dateInfo.weekday == "일"
+                    ? "date-choose-sun"
+                    : ""
+                }`}
+                onClick={() => {
+                  setChosenDateIndex(index);
+                  setSelectedDate(dateInfo.date);
+                }}
+              >
+                <div
+                  className={`day ${
+                    chosenDateIndex == index ? "choose-date" : ""
+                  }`}
+                >
+                  {dateInfo.day}
+                </div>
+                <div className="date">
+                  {index == 0 ? "오늘" : dateInfo.weekday}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="date-arrows-area">
+          <div className="left-arrow" onClick={handlePrev}>
+            ‹
+          </div>
+          <div className="right-arrow" onClick={handleNext}>
+            ›
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DateSlider;

--- a/src/components/MovieSelection.css
+++ b/src/components/MovieSelection.css
@@ -1,0 +1,27 @@
+.movie-selection {
+  background-color: rgb(226, 223, 210);
+  min-height: 300px;
+  max-height: calc(100dvh - 10dvh - 68px - 68px);
+  overflow: auto;
+  scroll-behavior: smooth;
+  scrollbar-width: thin;
+  ul {
+    padding-top: 1rem;
+    display: grid;
+    gap: 12px;
+    a {
+      cursor: pointer;
+      text-decoration: none;
+      padding-left: 1rem;
+      font-weight: 500;
+      display: flex;
+      align-items: center;
+
+      img {
+        margin-right: 8px;
+        width: 28px;
+        border-radius: 4px;
+      }
+    }
+  }
+}

--- a/src/components/MovieSelection.tsx
+++ b/src/components/MovieSelection.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from "react";
+import "./MovieSelection.css";
+import { useScheduleRelatedStore } from "../stores/ScheduleRelatedStore";
+import { getMovieInfo } from "../utils/scheduleRelatedUtils";
+import { fullScheduleProps } from "../types/ScheduleRelatedType";
+
+const MovieSelection: React.FC = () => {
+  const [movies, setMovies] = useState<fullScheduleProps[]>([]);
+  const { setSelectedMovie, setSelectedTheater } = useScheduleRelatedStore();
+
+  useEffect(() => {
+    const fetchMovies = async () => {
+      const data = await getMovieInfo();
+      if (data) {
+        setMovies(data);
+      }
+    };
+    fetchMovies();
+    setSelectedTheater(null);
+  }, [setSelectedTheater]);
+
+  return (
+    <div className="movie-selection">
+      <ul>
+        {movies.map((movie, id) => (
+          <li key={id}>
+            <a href="#none" onClick={() => setSelectedMovie(movie.movieName)}>
+              <img src={movie.grade} />
+              {movie.movieName}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default MovieSelection;

--- a/src/components/Navbar.css
+++ b/src/components/Navbar.css
@@ -4,10 +4,18 @@
 }
 .nav-bar {
   position: relative;
+  height: 10dvh;
   ul {
     li {
       a {
         font-weight: 500;
+        cursor: pointer;
+        text-decoration: none;
+        color: black;
+        opacity: 0.7;
+      }
+      a:hover {
+        opacity: 1;
       }
       button {
         background: #0e95d9e3;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -15,13 +15,13 @@ const Navbar: React.FC = () => {
       />
       <ul className="center-menu">
         <li>
-          <a href="#">영화</a>
+          <a className="middle-navigation">영화</a>
         </li>
         <li>
-          <a href="#">예매</a>
+          <a className="middle-navigation" onClick={() => navigate(AppRoutes.SCHEDULE_PAGE)}>예매</a>
         </li>
         <li>
-          <a href="#">상영관</a>
+          <a className="middle-navigation">상영관</a>
         </li>
       </ul>
       <ul>

--- a/src/components/PosterInfo.tsx
+++ b/src/components/PosterInfo.tsx
@@ -1,15 +1,6 @@
 import React from "react";
 import "./PosterInfo.css";
-
-type PosterInfoProps = {
-  movieName: string;
-  rating: number;
-  star: string;
-  image: string;
-  grade: string;
-  isReservable: boolean;
-  rank: number | null;
-};
+import { PosterInfoProps } from "../types/ScheduleRelatedType";
 
 const PosterInfo: React.FC<PosterInfoProps> = ({
   movieName,

--- a/src/components/ScheduleSelectArea.css
+++ b/src/components/ScheduleSelectArea.css
@@ -1,0 +1,75 @@
+.schedule-select-area {
+  display: grid;
+  padding: 0 20px;
+  margin-top: 24px;
+  .group-time-select {
+    display: grid;
+    margin-bottom: 2rem;
+    .movie-info-area {
+      display: flex;
+      align-items: center;
+      font-size: 20px;
+      font-weight: 600;
+      margin-bottom: 8px;
+      img {
+        width: 24px;
+        margin-right: 8px;
+      }
+    }
+    .time-select-wrapper {
+      display: grid;
+      gap: 1rem;
+      .time-select {
+        .hall {
+          font-size: 16px;
+          display: flex;
+          gap: 12px;
+          margin-bottom: 4px;
+        }
+        .main-schedule-area {
+          ul {
+            display: grid;
+            grid-template-columns: repeat(
+              auto-fill,
+              minmax(100px, 1fr)
+            ); /* auto-wrap columns */
+            row-gap: 8px;
+            column-gap: 20px;
+            padding: 0;
+            margin: 0;
+            li {
+              list-style: none;
+              button {
+                background-color: white;
+                border: 1px solid lightgray;
+                box-shadow: 1px 1px 4px rgb(120, 120, 120);
+                color: rgb(102 102 102);
+                .start-time {
+                  font-size: 20px;
+                  font-weight: 700;
+                  color: black;
+                }
+                .seat-info {
+                  font-size: 12px;
+                  font-weight: 500;
+                  .avail-seat {
+                    color: rgb(66 118 82);
+                  }
+                }
+              }
+              .selected-button {
+                border: 1px solid black;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  .no-schedule-avail{
+    display: grid;
+    justify-content: center;
+    font-size: 28px;
+    font-weight: 600;
+  }
+}

--- a/src/components/ScheduleSelectArea.tsx
+++ b/src/components/ScheduleSelectArea.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from "react";
+import "./ScheduleSelectArea.css";
+import { useScheduleRelatedStore } from "../stores/ScheduleRelatedStore";
+import { FullSchedule } from "../types/ScheduleRelatedType";
+import { getfullSchedule } from "../utils/scheduleRelatedUtils";
+
+const ScheduleSelectArea: React.FC = () => {
+  const [fullSchedule, setFullSchedule] = useState<FullSchedule[]>([]);
+  const { selectedDate, selectedTheater, selectedMovie } =
+    useScheduleRelatedStore();
+  const [selectedTime, setSelectedTime] = useState<string | null>(null);
+
+  //find schedule with selected date
+  const scheduleInfo =
+    fullSchedule.find((s) => s.date === selectedDate)?.schedules || [];
+
+  //Filter movies to only those with at least one matching theater,
+  //if nothing matched, show all movies
+  const filteredSchedules = scheduleInfo
+    .filter((movie) => !selectedMovie || movie.movieName === selectedMovie)
+    .filter((movie) =>
+      movie.theaters.some(
+        (theater) => !selectedTheater || theater.theaterName === selectedTheater
+      )
+    );
+
+  useEffect(() => {
+    const fetchFullSchedule = async () => {
+      const data = await getfullSchedule();
+      if (data) {
+        setFullSchedule(data);
+      }
+    };
+    fetchFullSchedule();
+  }, []);
+
+  return (
+    <div className="schedule-select-area">
+      {filteredSchedules.map((groupTime, index1) => (
+        <div className="group-time-select" key={index1}>
+          <div className="movie-info-area">
+            <img src={groupTime.grade} />
+            <span className="movie-name">{groupTime.movieName}</span>
+          </div>
+          <div className="time-select-wrapper">
+            {groupTime.theaters
+              .filter(
+                (theater) =>
+                  !selectedTheater || theater.theaterName === selectedTheater
+              )
+              .map((theater, index2) => (
+                <div className="time-select" key={index2}>
+                  <div className="hall">
+                    <span className="format">{theater.format}</span>
+                    {theater.subDub && (
+                      <span className="sub-dub">{theater.subDub}</span>
+                    )}
+                    <span className="hall-name">{theater.theaterName}</span>
+                  </div>
+                  <div className="main-schedule-area">
+                    <ul>
+                      {theater.startTimes.map((time, index3) => (
+                        <li className="main-schedule" key={index3}>
+                          <button
+                            data-tooltip={`종료 ${theater.endTimes[index3]}`}
+                            className={
+                              selectedTime ===
+                              `${groupTime.movieName}-${theater.theaterId}-${time}`
+                                ? "selected-button"
+                                : ""
+                            }
+                            onClick={() =>
+                              setSelectedTime(
+                                `${groupTime.movieName}-${theater.theaterId}-${time}`
+                              )
+                            }
+                          >
+                            <div className="start-time">{time}</div>
+                            <div className="seat-info">
+                              <span className="avail-seat">
+                                {theater.availSeat}
+                              </span>
+                              /
+                              <span className="total-seat">
+                                {theater.totalSeat}
+                              </span>
+                            </div>
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              ))}
+          </div>
+        </div>
+      ))}
+      {filteredSchedules.length === 0 && (
+        <p className="no-schedule-avail">
+          선택한 극장에서 상영 중인 영화가 없습니다.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default ScheduleSelectArea;

--- a/src/components/ScheduleSelector.css
+++ b/src/components/ScheduleSelector.css
@@ -1,0 +1,38 @@
+.theater-main-container {
+  display: grid;
+  grid-template-columns: 1fr 3fr;
+
+  .left-area,
+  .right-area {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 20px;
+    font-weight: 500;
+    height: 68px;
+    background-color: rgb(226, 226, 226);
+  }
+  .left-area {
+    background-color: rgb(226, 226, 226);
+    border-right: 1px solid darkgray;
+  }
+  .schedule-selection {
+    overflow: auto;
+    .schedule-list-wrapper {
+      scrollbar-width: thin;
+      scroll-behavior: smooth;
+      min-height: calc(300px - 97px);
+      max-height: calc(100dvh - 10dvh - 68px - 68px - 97px - 1px);  /*1: border-bottom*/
+      overflow-y: auto;
+      
+      .schedule-list {
+        max-height: 100%;
+        overflow: auto;
+        height: max-content;
+      }
+    }
+  }
+}
+.schedule-selection::-webkit-scrollbar {
+  display: none;
+}

--- a/src/components/ScheduleSelector.tsx
+++ b/src/components/ScheduleSelector.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import "./ScheduleSelector.css";
+import DateSlider from "./DateSlider";
+import ScheduleSelectArea from "./ScheduleSelectArea";
+import TheaterSelection from "./TheaterSelection";
+import { useScheduleRelatedStore } from "../stores/ScheduleRelatedStore";
+import MovieSelection from "./MovieSelection";
+
+const ScheduleSelector: React.FC = () => {
+  const today = new Date();
+  const formatted = today.toISOString().split("T")[0]; // "2025-05-14"
+  const dayName = today.toLocaleDateString("ko-KR", { weekday: "short" }); //"월", "화"
+  const { selectedTheater, scheduleViewType, selectedDate, selectedMovie } =
+    useScheduleRelatedStore();
+
+  return (
+    <div className="theater-main-container">
+      <div className="left-area">
+        {scheduleViewType == "theater" ? selectedTheater : selectedMovie}
+      </div>
+      <div className="right-area">
+        {selectedDate ? selectedDate : formatted}({dayName})
+      </div>
+      {scheduleViewType == "theater" ? (
+        <TheaterSelection />
+      ) : (
+        <MovieSelection />
+      )}
+      <div className="schedule-selection">
+        <DateSlider />
+        <div className="schedule-list-wrapper">
+          <div className="schedule-list">
+            <ScheduleSelectArea />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ScheduleSelector;

--- a/src/components/TheaterSelection.css
+++ b/src/components/TheaterSelection.css
@@ -1,0 +1,19 @@
+.location-selection {
+  background-color: rgba(226, 226, 226, .8);
+  min-height: 300px;
+  max-height: calc(100dvh - 10dvh - 68px - 68px);
+  overflow: auto;
+  scroll-behavior: smooth;
+  scrollbar-width: thin;
+  ul {
+    padding-top: 1rem;
+    display: grid;
+    gap: 4px;
+    a {
+      cursor: pointer;
+      text-decoration: none;
+      padding-left: 1rem;
+      font-weight: 500;
+    }
+  }
+}

--- a/src/components/TheaterSelection.tsx
+++ b/src/components/TheaterSelection.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from "react";
+import { useScheduleRelatedStore } from "../stores/ScheduleRelatedStore";
+import "./TheaterSelection.css";
+import { getTheatersInfo } from "../utils/scheduleRelatedUtils";
+import { TheaterInSchedule } from "../types/ScheduleRelatedType";
+
+
+const TheaterSelection: React.FC = () => {
+  const [theaters, setTheaters] = useState<TheaterInSchedule[]>([]);
+  const { setSelectedTheater, setSelectedMovie } = useScheduleRelatedStore();
+
+
+  useEffect(() => {
+    const fetchTheaters = async () => {
+      const data = await getTheatersInfo();
+      if (data) {
+        setTheaters(data);
+      }
+    };
+    fetchTheaters();
+    setSelectedMovie(null);
+  }, [setSelectedMovie]);
+
+  return (
+    <div className="location-selection">
+      <ul>
+        {theaters.map((theater, id) => (
+          <li key={id}>
+            <a
+              href="#none"
+              onClick={() => setSelectedTheater(theater.theaterName)}
+            >
+              {theater.theaterName}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default TheaterSelection;

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -4,7 +4,7 @@
 .slider {
   width: 1600px;
   max-width: 100%;
-  margin: 100px auto 20px;
+  margin: 40px auto 20px;
   overflow: auto;
   scroll-behavior: smooth;
   scroll-snap-type: both;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,6 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Navbar from "../components/Navbar";
-import PosterInfo from "../components/PosterInfo";
+import PosterInfo, { PosterInfoProps } from "../components/PosterInfo";
 import "./HomePage.css";
 
 const HomePage: React.FC = () => {
@@ -8,6 +8,26 @@ const HomePage: React.FC = () => {
   const isDragging = useRef(false);
   const startX = useRef(0); //X position where the user first started dragging.
   const startScrollLeft = useRef(0); //scroll position (how far slider was scrolled) when the user started dragging.
+  const [movieInfo, setMovieInfo] = useState<PosterInfoProps[]>([]);
+
+  ///////fetch movie's info
+  const getMovieInfo = async () => {
+    try {
+      const response = await fetch("/src/assets/cinema_info/mock_cinema.json");
+      if (!response.ok) {
+        throw new Error("Failed to fetch cinema's info");
+      }
+      const data = await response.json();
+      setMovieInfo(data);
+      return data;
+    } catch (error) {
+      console.log("error: ", error);
+    }
+  };
+
+  useEffect(() => {
+    getMovieInfo();
+  }, []);
 
   //////////////////////////// Handle slider's button click
   function handleNext() {
@@ -74,138 +94,39 @@ const HomePage: React.FC = () => {
       <div className="navbar-wrapper">
         <Navbar />
       </div>
-      <div className="slider-container">
-        <div
-          className="slider"
-          ref={sliderRef}
-          onMouseDown={handleDragStart}
-          onMouseMove={handleDragMove}
-          onMouseUp={handleDragEnd}
-          onMouseLeave={handleDragEnd}
-          onTouchStart={handleDragStart}
-          onTouchMove={handleDragMove}
-          onTouchEnd={handleDragEnd}
-        >
-          <div className="posters-area">
-            <div className="item-container">
+      <div
+        className="slider"
+        ref={sliderRef}
+        onMouseDown={handleDragStart}
+        onMouseMove={handleDragMove}
+        onMouseUp={handleDragEnd}
+        onMouseLeave={handleDragEnd}
+        onTouchStart={handleDragStart}
+        onTouchMove={handleDragMove}
+        onTouchEnd={handleDragEnd}
+      >
+        <div className="posters-area">
+          {movieInfo.map((movie, index) => (
+            <div className="item-container" key={index}>
               <PosterInfo
-                movieName="거룩한 밤: 데몬 헌텃스 1"
-                rating={26.7}
-                star="8"
-                image="/src/assets/movie1.jpg"
-                grade="/src/assets/grade_15.png"
-                isReservable={true}
-                rank={1}
+                movieName={movie.movieName}
+                rating={movie.rating}
+                star={movie.star}
+                image={movie.image}
+                grade={movie.grade}
+                isReservable={movie.isReservable}
+                rank={movie.rank}
               />
             </div>
-            <div className="item-container">
-              <PosterInfo
-                movieName="거룩한 밤: 데몬 헌텃스 2"
-                rating={25.7}
-                star="8"
-                image="/src/assets/movie1.jpg"
-                grade="/src/assets/grade_15.png"
-                isReservable={true}
-                rank={2}
-              />
-            </div>
-            <div className="item-container">
-              <PosterInfo
-                movieName="거룩한 밤: 데몬 헌텃스 3"
-                rating={24.7}
-                star="8"
-                image="/src/assets/movie1.jpg"
-                grade="/src/assets/grade_15.png"
-                isReservable={true}
-                rank={3}
-              />
-            </div>
-            <div className="item-container">
-              <PosterInfo
-                movieName="거룩한 밤: 데몬 헌텃스 4"
-                rating={23.7}
-                star="8"
-                image="/src/assets/movie1.jpg"
-                grade="/src/assets/grade_15.png"
-                isReservable={true}
-                rank={4}
-              />
-            </div>
-            <div className="item-container">
-              <PosterInfo
-                movieName="거룩한 밤: 데몬 헌텃스 5"
-                rating={22.7}
-                star="8"
-                image="/src/assets/movie1.jpg"
-                grade="/src/assets/grade_15.png"
-                isReservable={false}
-                rank={5}
-              />
-            </div>
-            <div className="item-container">
-              <PosterInfo
-                movieName="거룩한 밤: 데몬 헌텃스 6"
-                rating={21.7}
-                star="8"
-                image="/src/assets/movie1.jpg"
-                grade="/src/assets/grade_15.png"
-                isReservable={true}
-                rank={6}
-              />
-            </div>
-            <div className="item-container">
-              <PosterInfo
-                movieName="거룩한 밤: 데몬 헌텃스 7"
-                rating={20.7}
-                star="8"
-                image="/src/assets/movie1.jpg"
-                grade="/src/assets/grade_15.png"
-                isReservable={false}
-                rank={7}
-              />
-            </div>
-            <div className="item-container">
-              <PosterInfo
-                movieName="거룩한 밤: 데몬 헌텃스 8"
-                rating={21.7}
-                star="8"
-                image="/src/assets/movie1.jpg"
-                grade="/src/assets/grade_15.png"
-                isReservable={false}
-                rank={null}
-              />
-            </div>
-            <div className="item-container">
-              <PosterInfo
-                movieName="거룩한 밤: 데몬 헌텃스 9"
-                rating={22.7}
-                star="8"
-                image="/src/assets/movie1.jpg"
-                grade="/src/assets/grade_15.png"
-                isReservable={false}
-                rank={null}
-              />
-            </div>
-            <div className="item-container">
-              <PosterInfo
-                movieName="거룩한 밤: 데몬 헌텃스 10"
-                rating={21.7}
-                star="8"
-                image="/src/assets/movie1.jpg"
-                grade="/src/assets/grade_15.png"
-                isReservable={false}
-                rank={null}
-              />
-            </div>
-          </div>
+          ))}
         </div>
-        <div className="arrows-area">
-          <div className="left-arrow" onClick={handlePrev}>
-            <img src="/src/assets/arrow_left_white.png" alt="left arrow" />
-          </div>
-          <div className="right-arrow" onClick={handleNext}>
-            <img src="/src/assets/arrow_right_white.png" alt="right arrow" />
-          </div>
+      </div>
+      <div className="arrows-area">
+        <div className="left-arrow" onClick={handlePrev}>
+          <img src="/src/assets/arrow_left_white.png" alt="left arrow" />
+        </div>
+        <div className="right-arrow" onClick={handleNext}>
+          <img src="/src/assets/arrow_right_white.png" alt="right arrow" />
         </div>
       </div>
     </div>

--- a/src/pages/SchedulePage.css
+++ b/src/pages/SchedulePage.css
@@ -1,0 +1,28 @@
+.schedule-main-area {
+  min-height: 90dvh;
+  display: grid;
+  justify-content: center;
+  align-items: center;
+  color: black;
+
+  .content {
+    width: 80dvw;
+    height: 100%;
+    background-color: white;
+
+    .hall-and-movie-wrapper {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+
+      button {
+        border-radius: 0;
+        height: 68px;
+        border: none;
+        background-color: rgb(111, 120, 135);
+      }
+      .selected-btn {
+        background-color: rgb(1, 127, 192);
+      }
+    }
+  }
+}

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import "./SchedulePage.css";
+import Navbar from "../components/Navbar";
+import { useScheduleRelatedStore } from "../stores/ScheduleRelatedStore";
+import ScheduleSelector from "../components/ScheduleSelector";
+
+const SchedulePage: React.FC = () => {
+  const { scheduleViewType, setScheduleViewType } = useScheduleRelatedStore();
+  return (
+    <div className="schedule-page-main">
+      <div className="navbar-wrapper">
+        <Navbar />
+      </div>
+      <div className="schedule-main-area">
+        <div className="content">
+          <div className="hall-and-movie-wrapper">
+            <button
+              className={`"hall-schedule-btn" ${scheduleViewType == "theater" ?"selected-btn" : ""}`}
+              onClick={() => setScheduleViewType("theater")}
+            >
+              상영관별 상영시간표
+            </button>
+            <button
+              className={`"movie-schedule-btn" ${scheduleViewType == "movie" ?"selected-btn" : ""}`}
+              onClick={() => setScheduleViewType("movie")}
+            >
+              영화별 상영시간표
+            </button>
+          </div>
+          <ScheduleSelector />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SchedulePage;

--- a/src/routes/AppRoutes.ts
+++ b/src/routes/AppRoutes.ts
@@ -3,4 +3,5 @@ export enum AppRoutes {
   SEAT_SELECTION_PAGE = "/seat-selection-page",
   LOGIN_PAGE = "/login-page",
   SIGN_UP_PAGE = "/sign-up-page",
+  SCHEDULE_PAGE = "/schedule-page",
 }

--- a/src/routes/MyRoute.tsx
+++ b/src/routes/MyRoute.tsx
@@ -4,6 +4,7 @@ import { AppRoutes } from "./AppRoutes";
 import HomePage from "../pages/HomePage";
 import LoginPage from "../pages/LoginPage";
 import SignUpPage from "../pages/SignUpPage";
+import SchedulePage from "../pages/SchedulePage";
 
 const MyRoute: React.FC = () => {
   return (
@@ -12,6 +13,7 @@ const MyRoute: React.FC = () => {
         <Route path={AppRoutes.HOME} element={<HomePage />} />
         <Route path={AppRoutes.LOGIN_PAGE} element={<LoginPage />} />
         <Route path={AppRoutes.SIGN_UP_PAGE} element={<SignUpPage />} />
+        <Route path={AppRoutes.SCHEDULE_PAGE} element={<SchedulePage />} />
       </Routes>
     </>
   );

--- a/src/stores/ScheduleRelatedStore.ts
+++ b/src/stores/ScheduleRelatedStore.ts
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+
+type ScheduleRelatedStore = {
+  selectedDate: string;
+  setSelectedDate: (date: string) => void;
+  selectedTheater: string | null;
+  setSelectedTheater: (theater: string | null) => void;
+  scheduleViewType: string;
+  setScheduleViewType: (viewType: string) => void;
+  selectedMovie: string | null;
+  setSelectedMovie: (movie: string | null) => void;
+};
+
+export const useScheduleRelatedStore = create<ScheduleRelatedStore>((set) => ({
+  selectedDate: "2025-05-17", //temporary date for ui
+  setSelectedDate: (date) => set({ selectedDate: date }),
+  selectedTheater: null,
+  setSelectedTheater: (theater) => set({ selectedTheater: theater }),
+  scheduleViewType: "theater",
+  setScheduleViewType: (viewType) => set({ scheduleViewType: viewType }),
+  selectedMovie: null,
+  setSelectedMovie: (movie) => set({ selectedMovie: movie }),
+}));

--- a/src/types/scheduleRelatedType.ts
+++ b/src/types/scheduleRelatedType.ts
@@ -1,0 +1,30 @@
+//used in ScheduleSelectArea.tsx
+export type FullSchedule = {
+  date: string;
+  schedules: fullScheduleProps[];
+};
+export type fullScheduleProps = {
+  movieName: string;
+  durationMinutes: number;
+  grade: string;
+  theaters: TheaterInSchedule[];
+};
+export type TheaterInSchedule = {
+  theaterId: string;
+  theaterName: string;
+  format: string;
+  subDub: string | null;
+  availSeat: number;
+  totalSeat: number;
+  startTimes: string[];
+  endTimes: string[];
+};
+export type PosterInfoProps = {
+  movieName: string;
+  rating: number;
+  star: number | null;
+  image: string;
+  grade: string;
+  isReservable: boolean;
+  rank: number | null;
+};

--- a/src/utils/scheduleRelatedUtils.ts
+++ b/src/utils/scheduleRelatedUtils.ts
@@ -1,0 +1,92 @@
+export const getTheatersInfo = async () => {
+  try {
+    const response = await fetch("/src/assets/theater_info/mock_theater.json");
+    if (!response.ok) {
+      throw new Error("Failed to fetch theater's info");
+    }
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.log("error: ", error);
+  }
+};
+
+export const getMovieInfo = async () => {
+  try {
+    const response = await fetch("/src/assets/cinema_info/mock_cinema.json");
+    if (!response.ok) {
+      throw new Error("Failed to fetch theater's info");
+    }
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.log("error: ", error);
+  }
+};
+
+export const getfullSchedule = async () => {
+    try {
+      const response = await fetch("/src/assets/schedule/mock_schedule.json");
+      if (!response.ok) {
+        throw new Error("Failed to fetch schedule");
+      }
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      console.log("error: ", error);
+    }
+  };
+
+//will be deleted later when fetch with real api
+export const mockDates = [
+  { date: "2025-05-17" },
+  { date: "2025-05-18" },
+  { date: "2025-05-19" },
+  { date: "2025-05-20" },
+  { date: "2025-05-21" },
+  { date: "2025-05-22" },
+  { date: "2025-05-23" },
+  { date: "2025-05-24" },
+  { date: "2025-05-25" },
+  { date: "2025-05-26" },
+  { date: "2025-05-27" },
+  { date: "2025-05-28" },
+  { date: "2025-05-29" },
+  { date: "2025-05-30" },
+  { date: "2025-05-31" },
+  { date: "2025-06-01" },
+  { date: "2025-06-02" },
+  { date: "2025-06-03" },
+  { date: "2025-06-04" },
+  { date: "2025-06-05" },
+];
+//will be deleted later when fetch with real api
+export const mockDateList = mockDates.map((entry) => {
+  const dateObj = new Date(entry.date);
+  return {
+    date: entry.date,
+    day: dateObj.getDate(),
+    month: dateObj.getMonth() + 1,
+    weekday: dateObj.toLocaleDateString("ko-KR", { weekday: "short" }), // "토", "일", ...
+  };
+});
+
+//get days' info from today to 'count' days later, getDaysWithWeekday(20): get 20 days' info from today
+export function getDaysWithWeekday(
+  count: number
+): { day: number; weekday: string; month: number }[] {
+  const today = new Date();
+  const result = [];
+
+  for (let i = 0; i <= count; i++) {
+    const date = new Date(today);
+    date.setDate(today.getDate() + i);
+
+    const day = date.getDate();
+    const month = date.getMonth() + 1; // getMonth() is 0-based (0 = Jan, so add 1)
+    const weekday = date.toLocaleDateString("ko-KR", { weekday: "short" });
+
+    result.push({ day, weekday, month });
+  }
+  return result;
+}


### PR DESCRIPTION
## 상영일정 페이지 (Schedule Page):
### Route
- Navigates to the Schedule Page when clicking the **예매** link in the navigation bar.

### Features
- Users can filter schedules by **상영관**, **영화**, and **날짜**.
- Only movies matching the selected filters will be shown.
  - If no filters are selected, all schedules will be displayed by default.
- If the 영화, 상영관, or 상영일정 lists are long, **inner scroll** is applied to maintain layout.

### Date Slider:

- Users can control the date slider using arrow buttons.
- The slider displays dates from **today to 20 days ahead**.  
  Currently, due to the use of static mock data, the slider starts from a specific hardcoded date.  
  This will need to be updated when integrating real backend data.
- Clicking on a date:
  - Highlights the selected date.
  - Shows only movies scheduled for that day.


## General Updates:

- Added a fixed **height** for the navigation bar (to be refined later).
- Integrated **Zustand** for managing schedule-related state.
- Created **mock data files** for 영화, 상영관, and 상영일정.  
  ⚠️ Since the app currently uses only mock data, some logic may need to change when real backend data is introduced.
- Created a `types/` folder for better TypeScript type management.
- Created a `utils/scheduleRelatedUtils/` folder for organizing schedule-related utilities and mock data.

## Future improvement
- Make the page **responsive** across devices.
- Add a **sub-tab** under the 예매 menu for easier navigation to reservation-related pages (on hover).

-----
### Screenshot:
- 상영관별 상영시간표
![image](https://github.com/user-attachments/assets/a01f61f6-ae74-4789-8d20-46b8bf329147)
- 영화별 상영시간표
![image](https://github.com/user-attachments/assets/16b5225d-017f-43a2-90f3-a813cc1ee871)

