### PR TITLE
Implement 결제페이지

### DIFF
--- a/src/components/ScheduleSelectArea/ScheduleSelectArea.tsx
+++ b/src/components/ScheduleSelectArea/ScheduleSelectArea.tsx
@@ -18,7 +18,6 @@ const ScheduleSelectArea: React.FC = () => {
     setSelectedGrade,
     setSelectedFormat,
     setSelectedScreenTime,
-    selectedGrade
   } = useScheduleRelatedStore();
   const [selectedTime, setSelectedTime] = useState<string | null>(null);
 
@@ -49,7 +48,6 @@ const ScheduleSelectArea: React.FC = () => {
     setSelectedMovie(movieName);
     setSelectedGrade(grade);
     setSelectedFormat(format);
-    console.log(selectedGrade);
     navigate(AppRoutes.SEAT_SELECTION_PAGE);
   }
 

--- a/src/pages/PaymentPage/PaymentPage.css
+++ b/src/pages/PaymentPage/PaymentPage.css
@@ -1,0 +1,209 @@
+.payment-page-main {
+  min-height: 90dvh;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+}
+.area-title {
+  background-color: black;
+  color: white;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 60px;
+  font-weight: 500;
+}
+.bottom-left {
+  padding: 2rem;
+  display: grid;
+  justify-content: center;
+
+  .poster-area {
+    display: flex;
+    justify-content: center;
+    .poster-image {
+      height: 400px;
+      border-radius: 12px;
+    }
+  }
+  .schedule-info-area {
+    margin-top: 1rem;
+    font-size: 20px;
+
+    .title-format-grade-area {
+      display: flex;
+      align-items: center;
+      font-size: 28px;
+      font-weight: 600;
+
+      img {
+        width: 28px;
+        border-radius: 4px;
+        margin-right: 8px;
+      }
+    }
+    .date-and-time {
+      font-weight: 500;
+      margin-top: 8px;
+      .date-span {
+        margin-right: 16px;
+      }
+    }
+    .theater-info-area,
+    .seat-info-area {
+      font-weight: 500;
+    }
+  }
+}
+
+.middle {
+  background-color: rgb(246, 243, 243);
+  border-inline: 1px solid darkgray;
+}
+.bottom-middle {
+  display: grid;
+  grid-template-rows: calc((100dvh - 10dvh - 60px) / 2) calc(
+      (100dvh - 10dvh - 60px) / 2
+    );
+  font-size: 20px;
+
+  .discount-area {
+    border-bottom: 1px solid darkgray;
+  }
+  .discount-method-selection,
+  .payment-method-selection {
+    display: flex;
+    align-items: center;
+    justify-content: space-evenly;
+    margin-top: 1rem;
+    cursor: pointer;
+  }
+
+  .discount-method-selection > *,
+  .payment-method-selection > * {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 140px;
+    padding: 8px;
+    background-color: white;
+    border: 1px solid lightgray;
+    border-radius: 4px;
+  }
+}
+.area-label,
+.discount-input-area {
+  font-size: 16px;
+  font-weight: 500;
+  padding: 2rem 0 0 2rem;
+}
+.discount-input-area {
+  input {
+    width:unset;
+    height: 32px;
+    padding: unset;
+    font-size: 16px;
+    margin-right: 12px;
+  }
+  button {
+    background-color: rgb(0, 146, 202);
+    padding: 4px;
+    font-size: 16px;
+    font-weight: 500;
+  }
+}
+
+.payment-page-main .right {
+  background-color: rgb(207, 207, 207);
+}
+.bottom-right {
+  display: grid;
+  align-items: center;
+  padding: 2rem;
+  color: rgb(238, 238, 238);
+
+  .payment-details-area {
+    background-color: rgb(57, 62, 70);
+    padding: 1rem;
+    border-radius: 12px;
+    display: grid;
+  }
+  .payment-button {
+    background-color: rgb(0, 146, 202);
+    border: none;
+    padding: 8px 0;
+    margin-top: 2rem;
+  }
+  .attendies-total-area {
+    font-size: 20px;
+    font-weight: 400;
+    border-bottom: 1px solid darkgray;
+    margin-bottom: 1rem;
+  }
+  .attendies-money-wrap {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+  }
+  .ticket-money-area,
+  .discount-money-area,
+  .total-payment-area {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+    font-weight: 500;
+  }
+}
+
+@media screen and (max-width: 1300px) {
+  .bottom-left,
+  .right .bottom-right {
+    padding: 1rem;
+  }
+  .area-label,
+  .discount-input-area {
+    font-size: 12px;
+    padding: 1rem 0 0 1rem;
+  }
+
+  .bottom-left {
+    .poster-area .poster-image {
+      height: 200px;
+    }
+    .schedule-info-area {
+      font-size: 16px;
+      .title-format-grade-area {
+        font-size: 24px;
+      }
+    }
+  }
+
+  .bottom-middle {
+    font-size: 16px;
+    .discount-method-selection,
+    .payment-method-selection {
+      margin-top: 12px;
+    }
+
+    .discount-method-selection > *,
+    .payment-method-selection > * {
+      width: 120px;
+      padding: 4px;
+    }
+  }
+
+  .bottom-right {
+    .attendies-money-wrap {
+      margin-bottom: 12px;
+    }
+    .attendies-total-area,
+    .ticket-money-area,
+    .discount-money-area,
+    .total-payment-area {
+      margin-bottom: 12px;
+      font-size: 16px;
+    }
+    .payment-button {
+      margin-top: 1rem;
+    }
+  }
+}

--- a/src/pages/PaymentPage/PaymentPage.tsx
+++ b/src/pages/PaymentPage/PaymentPage.tsx
@@ -1,0 +1,164 @@
+import React, { useState } from "react";
+import "./PaymentPage.css";
+import Navbar from "../../components/Navbar";
+import { useScheduleRelatedStore } from "../../stores/ScheduleRelatedStore";
+import { getWeekday } from "../../utils/scheduleRelatedUtils";
+
+const PaymentPage: React.FC = () => {
+  const {
+    selectedDate,
+    selectedTheater,
+    selectedMovie,
+    selectedGrade,
+    selectedFormat,
+    selectedScreenTime,
+    selectedPeople,
+    selectedSeats,
+  } = useScheduleRelatedStore();
+  const [discount, setDiscount] = useState("");
+  const discountPrice = 1000;
+
+  const PEOPLE_LABELS: Record<keyof typeof selectedPeople, string> = {
+    adult: "성인",
+    teen: "청소년",
+    senior: "경로",
+    kid: "어린이",
+    disabled: "장애인",
+  };
+  //display "성인 1, 청소년 1"
+  const peopleDisplay = Object.entries(selectedPeople)
+    .filter(([, count]) => count > 0)
+    .map(
+      ([key, count]) =>
+        `${PEOPLE_LABELS[key as keyof typeof selectedPeople]} ${count}`
+    )
+    .join(", ");
+
+  //display [1,2] -> A2
+  const getRowLabel = (row: number) => String.fromCharCode(64 + row);
+  const seatDisplay = selectedSeats
+    .map(([row, col]) => `${getRowLabel(row)}${col}`)
+    .join(", ");
+
+  const TICKET_PRICES: Record<keyof typeof selectedPeople, number> = {
+    adult: 15000,
+    teen: 10000,
+    senior: 8000,
+    kid: 7000,
+    disabled: 6000,
+  };
+  const peoplePrices = Object.entries(selectedPeople)
+    .filter(([, count]) => count > 0)
+    .map(([key, count]) => ({
+      label: `${PEOPLE_LABELS[key as keyof typeof selectedPeople]} ${count}`,
+      price: TICKET_PRICES[key as keyof typeof selectedPeople] * count,
+    }));
+  const totalPrice = peoplePrices.reduce((sum, p) => sum + p.price, 0);
+
+  return (
+    <div className="payment-page">
+      <div className="navbar-wrapper">
+        <Navbar />
+      </div>
+      <div className="payment-page-main">
+        <div className="left">
+          <div className="area-title">예매정보</div>
+          <div className="bottom-left">
+            <div className="poster-area">
+              <img
+                src="/src/assets/movie1.jpg"
+                alt=""
+                className="poster-image"
+              />
+            </div>
+            <div className="schedule-info-area">
+              <div className="title-format-grade-area">
+                <span>
+                  <img src={`${selectedGrade}`} alt="15" />
+                </span>
+                <span>{selectedMovie}</span>
+                <span>({selectedFormat})</span>
+              </div>
+              <div className="date-and-time">
+                <span className="date-span">
+                  {selectedDate}({getWeekday(selectedDate)})
+                </span>
+                <span>
+                  {selectedScreenTime?.[0]} ~ {selectedScreenTime?.[1]}
+                </span>
+              </div>
+              <div className="theater-info-area">{selectedTheater}</div>
+              <div className="people-area">{peopleDisplay}</div>
+              <div className="seat-info-area">{seatDisplay}</div>
+            </div>
+          </div>
+        </div>
+        <div className="middle">
+          <div className="area-title">결제수단</div>
+          <div className="bottom-middle">
+            <div className="discount-area">
+              <div className="area-label">할인/포인트</div>
+              <div className="discount-method-selection">
+                <div onClick={() => setDiscount("coupon")}>할인권</div>
+                <div onClick={() => setDiscount("point")}>포인트 조회</div>
+              </div>
+              {discount && (
+                <div className="discount-input-area">
+                  <label htmlFor="coupon">
+                    {discount == "coupon"
+                      ? "할인권코드"
+                      : discount == "point"
+                      ? "포인트"
+                      : ""}
+                  </label>
+                  <input type="text" id="coupon" name="coupon" />
+                  <button onClick={() => setDiscount("")}>사용</button>
+                </div>
+              )}
+            </div>
+            <div className="payment-method-area">
+              <div className="area-label">최종 결제수단</div>
+              <div className="payment-method-selection">
+                <div>신용/체크카드</div>
+                <div>간편결제</div>
+                <div>휴대폰 결제</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="right">
+          <div className="area-title">결제하기</div>
+          <div className="bottom-right">
+            <div className="payment-details-area">
+              <div className="people-money-area">
+                <div className="attendies-total-area">
+                  {peoplePrices.map((item, idex) => (
+                    <div className="attendies-money-wrap" key={idex}>
+                      <span>{item.label}</span>
+                      <span>{item.price.toLocaleString()}원</span>
+                    </div>
+                  ))}
+                </div>
+                <div className="ticket-money-area">
+                  <span>상품금액</span>
+                  <span>{totalPrice.toLocaleString()}원</span>
+                </div>
+                <div className="discount-money-area">
+                  <span>할인금액</span>
+                  <span>-{discountPrice.toLocaleString()}원</span>
+                </div>
+                <div className="total-payment-area">
+                  <span>최종 결제 금액</span>
+                  <span>{(totalPrice - discountPrice).toLocaleString()}원</span>
+                </div>
+              </div>
+              <button className="payment-button">결제하기</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PaymentPage;

--- a/src/pages/SeatSelectionPage/SeatSelectionPage.tsx
+++ b/src/pages/SeatSelectionPage/SeatSelectionPage.tsx
@@ -4,8 +4,12 @@ import { useScheduleRelatedStore } from "../../stores/ScheduleRelatedStore";
 import TheaterSeatMap from "../../components/TheaterList/TheaterSeatMap";
 import theaters from "../../assets/theater_info/mock_seat.json";
 import Navbar from "../../components/Navbar";
+import { useNavigate } from "react-router-dom";
+import { AppRoutes } from "../../routes/AppRoutes";
 
 const SeatSelectionPage: React.FC = () => {
+  const navigate = useNavigate();
+
   const {
     selectedDate,
     selectedTheater,
@@ -52,6 +56,26 @@ const SeatSelectionPage: React.FC = () => {
     }
   }
 
+  function handleNavigatePayment() {
+    const totalPeople =
+      selectedPeople.adult +
+      selectedPeople.teen +
+      selectedPeople.senior +
+      selectedPeople.kid +
+      selectedPeople.disabled;
+    
+    if (
+      selectedDate &&
+      selectedTheater &&
+      selectedMovie &&
+      selectedScreenTime &&
+      selectedPeople &&
+      selectedSeats.length == totalPeople
+    ) {
+      navigate(AppRoutes.PAYMENT_PAGE);
+    }
+  }
+
   return (
     <div className="seat-select-page">
       <div className="navbar-wrapper">
@@ -80,7 +104,9 @@ const SeatSelectionPage: React.FC = () => {
                       className="grade-image"
                     />
                   </span>
-                  <p className="seat-page-movie-title">{selectedMovie} ({selectedFormat})</p>
+                  <p className="seat-page-movie-title">
+                    {selectedMovie} ({selectedFormat})
+                  </p>
                 </div>
                 <div className="schedule-info">
                   <div className="date-and-time-area">
@@ -244,7 +270,12 @@ const SeatSelectionPage: React.FC = () => {
                 </span>
               </span>
             </div>
-            <button className="right-pay-button">결제하기</button>
+            <button
+              className="right-pay-button"
+              onClick={() => handleNavigatePayment()}
+            >
+              결제하기
+            </button>
           </div>
         </div>
       </div>

--- a/src/routes/AppRoutes.ts
+++ b/src/routes/AppRoutes.ts
@@ -8,4 +8,5 @@ export enum AppRoutes {
   SCHEDULE_PAGE = "/schedule-page",
   RESERVATION_PAGE = "/reservation-page",
   SEAT_SELECTION_PAGE = "/seat-selection-page",
+  PAYMENT_PAGE = "/payment-page",
 }

--- a/src/routes/MyRoute.tsx
+++ b/src/routes/MyRoute.tsx
@@ -10,6 +10,7 @@ import TheaterListPage from "../pages/TheaterListPage";
 import SchedulePage from "../pages/SchedulePage/SchedulePage";
 import ReservationPage from "../pages/ReservationPage/ReservationPage";
 import SeatSelectionPage from "../pages/SeatSelectionPage/SeatSelectionPage";
+import PaymentPage from "../pages/PaymentPage/PaymentPage";
 
 const MyRoute: React.FC = () => {
   return (
@@ -33,6 +34,7 @@ const MyRoute: React.FC = () => {
           element={<ReservationPage />}
         />
         <Route path={AppRoutes.SEAT_SELECTION_PAGE} element={<SeatSelectionPage />} />
+        <Route path={AppRoutes.PAYMENT_PAGE} element={<PaymentPage />} />
       </Routes>
     </>
   );

--- a/src/stores/ScheduleRelatedStore.ts
+++ b/src/stores/ScheduleRelatedStore.ts
@@ -30,22 +30,6 @@ type ScheduleRelatedStore = {
   setSelectedSeats: (seats: number[][]) => void;
 };
 
-// export const useScheduleRelatedStore = create<ScheduleRelatedStore>((set) => ({
-//   selectedDate: "2025-05-17", //temporary date for ui
-//   setSelectedDate: (date) => set({ selectedDate: date }),
-//   selectedTheater: null,
-//   setSelectedTheater: (theater) => set({ selectedTheater: theater }),
-//   scheduleViewType: "theater",
-//   setScheduleViewType: (viewType) => set({ scheduleViewType: viewType }),
-//   selectedMovie: null,
-//   setSelectedMovie: (movie) => set({ selectedMovie: movie }),
-//   selectedScreenTime: null,
-//   setSelectedScreenTime: (screenTime) =>
-//     set({ selectedScreenTime: screenTime }),
-//   selectedPeople: 0,
-//   setSelectedPeople: (people) => set({ selectedPeople: people }),
-// }));
-
 export const useScheduleRelatedStore = create<ScheduleRelatedStore>()(
   persist(
     (set) => ({

--- a/src/utils/scheduleRelatedUtils.ts
+++ b/src/utils/scheduleRelatedUtils.ts
@@ -25,17 +25,17 @@ export const getMovieInfo = async () => {
 };
 
 export const getfullSchedule = async () => {
-    try {
-      const response = await fetch("/src/assets/schedule/mock_schedule.json");
-      if (!response.ok) {
-        throw new Error("Failed to fetch schedule");
-      }
-      const data = await response.json();
-      return data;
-    } catch (error) {
-      console.log("error: ", error);
+  try {
+    const response = await fetch("/src/assets/schedule/mock_schedule.json");
+    if (!response.ok) {
+      throw new Error("Failed to fetch schedule");
     }
-  };
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.log("error: ", error);
+  }
+};
 
 //will be deleted later when fetch with real api
 export const mockDates = [
@@ -89,4 +89,10 @@ export function getDaysWithWeekday(
     result.push({ day, weekday, month });
   }
   return result;
+}
+
+export function getWeekday(dateStr: string) {
+  const date = new Date(dateStr);
+  const weekday = date.toLocaleDateString("ko-KR", { weekday: "short" });
+  return weekday;
 }


### PR DESCRIPTION
## 💳 결제 페이지 (Payment Page)

### 📍 Route
- Navigates to the Payment Page when the user clicks the **"결제"** button after selecting seats on the Seat Selection Page.

### 🧩 Features
- Displays key schedule information in a compact layout (movie title, screening time, format, age rating, poster).
- Shows the total ticket price based on the selected number of people.

---

## 🛠 General Updates
- Page is currently responsive for screens **1200px or wider**.
- Fixed minor logic issues and removed unnecessary code.

---

## 🚧 Future Improvements
- Add a **reset** or **go back** button for better navigation.
- Implement the **discount/points input field**:
  - After entering a 할인코드 or 포인트 and clicking the **"사용"** button, the discount should be reflected below the button.
- Reset store state when leaving the page.
- Add toggle functionality and styling for:
  - **결제수단 (Payment Method)** area
  - **할인/포인트 (Discount/Points)** area
- Prevent direct URL access to the Payment Page without completing prior steps.
- Make the page responsive across various devices and screen sizes.
- Improve overall UI design (e.g., colors, spacing).
- Dynamically change the seat layout depending on the selected theater (may require updating mock data).

---

### 🖼 Screenshot

**결제 페이지 (Payment Page)**  
![image](https://github.com/user-attachments/assets/434321a7-3abd-45f0-9c4d-79faba2002f7)
