### PR TITLE
Implement 티켓 페이지

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from "react";
 import { BrowserRouter } from "react-router-dom";
 import MyRoute from "./routes/MyRoute";
 import { isTokenValid } from "./utils/authUtils";
-import { useCinemaRelatedStore } from "./stores/CinemaRelatedStore";
 
 const App: React.FC = () => {
   useEffect(() => {
@@ -12,7 +11,6 @@ const App: React.FC = () => {
       localStorage.removeItem("access_token");
       localStorage.removeItem("expires_at");
     }
-    useCinemaRelatedStore.getState().setIsLogin(valid);
   }, []);
 
   return (

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,21 +3,17 @@ import { useNavigate } from "react-router-dom";
 import { AppRoutes } from "../routes/AppRoutes";
 import "./Navbar.css";
 import logoImage from "../assets/image/logo-transparent-bg.png";
-import { useCinemaRelatedStore } from "../stores/CinemaRelatedStore";
 import { isTokenValid, logout } from "../utils/authUtils";
 import { useScheduleRelatedStore } from "../stores/ScheduleRelatedStore";
 
 const Navbar: React.FC = () => {
   const navigate = useNavigate();
-  const setIsLogin = useCinemaRelatedStore((state) => state.setIsLogin);
 
   function handleLogout() {
     // Clear token from localStorage
     logout();
     // Reset Zustand booking state (in memory)
     useScheduleRelatedStore.getState().resetState();
-    // Update login state in auth store
-    setIsLogin(false);
 
     alert("로그아웃되었습니다.");
     navigate(AppRoutes.HOME);
@@ -81,7 +77,7 @@ const Navbar: React.FC = () => {
               <button onClick={handleLogout}>로그아웃</button>
             </li>
             <li>
-              <button>사용자 정보</button>
+              <button>마이</button>
             </li>
           </>
         ) : (

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,12 +1,10 @@
 import React, { useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import "./LoginPage.css";
-import { useCinemaRelatedStore } from "../stores/CinemaRelatedStore";
 
 const LoginPage: React.FC = () => {
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
-    const setIsLogin = useCinemaRelatedStore((state) => state.setIsLogin);
     const navigate = useNavigate();
     const location = useLocation();
     const from = location.state?.from || "/";
@@ -39,7 +37,6 @@ const LoginPage: React.FC = () => {
                 localStorage.setItem("expires_at", String(expiresAt));
                 
                 alert("로그인 성공!");
-                setIsLogin(true);
                 navigate(from, { replace: true });
             } else {
                 const errorData = await response.json();

--- a/src/pages/PaymentPage/PaymentPage.css
+++ b/src/pages/PaymentPage/PaymentPage.css
@@ -89,6 +89,9 @@
     border: 1px solid lightgray;
     border-radius: 4px;
   }
+  .selected-method {
+    box-shadow: 0px 0px 4px var(--primary-color);
+  }
 }
 .area-label,
 .discount-input-area {

--- a/src/pages/SeatSelectionPage/SeatSelectionPage.tsx
+++ b/src/pages/SeatSelectionPage/SeatSelectionPage.tsx
@@ -122,9 +122,7 @@ const SeatSelectionPage: React.FC = () => {
 
   useEffect(() => {
     if (!selectedMovie || !selectedScreenTime) {
-      console.log("Before alert2");
-      alert("Please select a movie and schedule first.");
-      console.log("After alert2");
+      alert("스케쥴 먼저 선택해주세요");
       navigate(AppRoutes.RESERVATION_PAGE, { replace: true });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -18,7 +18,6 @@ const SignUpPage: React.FC = () => {
                     'Content-Type': 'application/json',
                 },
                 body: JSON.stringify({
-                    id: 3785,
                     username: nickname,
                     email: email,
                     password: password

--- a/src/pages/TicketPage/TicketPage.css
+++ b/src/pages/TicketPage/TicketPage.css
@@ -1,0 +1,111 @@
+.ticket-page-main {
+  display: grid;
+  justify-content: center;
+  align-items: center;
+  min-height: 90dvh;
+  background-color: rgb(219 219 219);
+  .ticket-wrapper {
+    width: 400px;
+    background-color: white;
+    display: grid;
+    border-radius: 16px;
+    padding: 20px 32px;
+
+    .label-area {
+      color: rgb(150, 158, 175);
+      font-size: 16px;
+      font-weight: 500;
+      margin-top: 4px;
+    }
+
+    .ticket-main-info {
+      .ticket-top {
+        .ticket-title {
+          color: rgb(150, 158, 175);
+          font-size: 20px;
+          font-weight: 700;
+        }
+        .movie-title {
+          text-align: center;
+          margin-bottom: 0;
+        }
+        .grade {
+          font-size: 16px;
+          font-weight: 500;
+          text-align: center;
+        }
+        .theater {
+          font-weight: 700;
+        }
+      }
+
+      .ticket-middle {
+        display: grid;
+        align-items: center;
+        grid-template-columns: 1fr 1fr;
+
+        .date-area,
+        .time-area {
+          color: black;
+          font-size: 32px;
+          font-weight: 700;
+
+          span {
+            font-size: 16px;
+            font-weight: 500;
+          }
+        }
+      }
+
+      .ticket-bottom {
+        .seat-area {
+          display: flex;
+          align-items: center;
+          flex-wrap: wrap;
+          .seat-tag {
+            color: rgb(75 146 227);
+            background-color: rgb(202 227 255);
+            font-size: 16px;
+            font-weight: 500;
+            margin-right: 12px;
+            padding: 4px;
+            border-radius: 8px;
+            margin-top: 4px;
+          }
+        }
+        .people {
+          display: flex;
+          gap: 8px;
+          font-weight: 600;
+          font-size: 16px;
+          margin-top: 8px;
+        }
+      }
+    }
+    .payment-info-area {
+      margin-top: 16px;
+
+      span {
+        font-weight: 500;
+      }
+      .payment-amount {
+        font-size: 24px;
+        font-weight: 600;
+      }
+      .payment-method {
+        font-size: 20px;
+      }
+    }
+    button {
+      font-size: 16px;
+      padding: 8px;
+      color: rgb(150, 158, 175);
+      background-color: transparent;
+      border: 1px solid rgb(209, 213, 219);
+      justify-self: center;
+    }
+    button:hover {
+      box-shadow: 0px 0px 4px 2px inset rgb(233 233 233);
+    }
+  }
+}

--- a/src/pages/TicketPage/TicketPage.tsx
+++ b/src/pages/TicketPage/TicketPage.tsx
@@ -1,0 +1,144 @@
+import React, { useEffect } from "react";
+import "./TicketPage.css";
+import { usePaymentRelatedStore } from "../../stores/PaymentRelatedStore";
+import Navbar from "../../components/Navbar";
+import { useScheduleRelatedStore } from "../../stores/ScheduleRelatedStore";
+import {
+  extractGradeValue,
+  getMonthAndDay,
+  getWeekday,
+} from "../../utils/scheduleRelatedUtils";
+import {
+  getPaymentMethod,
+  getPeoplePrices,
+  getSeatSeparately,
+} from "../../utils/paymentUtils";
+import { useNavigate } from "react-router-dom";
+import { AppRoutes } from "../../routes/AppRoutes";
+
+const TicketPage: React.FC = () => {
+  const navigate = useNavigate();
+  // ------------------------- Access store
+  const paymentAmount = usePaymentRelatedStore((state) => state.paymentAmount);
+  const payMethod = usePaymentRelatedStore((state) => state.payMethod);
+  const hasPaid = usePaymentRelatedStore((state) => state.hasPaid);
+
+  const selectedMovie = useScheduleRelatedStore((state) => state.selectedMovie);
+  const selectedFormat = useScheduleRelatedStore(
+    (state) => state.selectedFormat
+  );
+  const selectedGrade = useScheduleRelatedStore((state) => state.selectedGrade);
+  const selectedTheater = useScheduleRelatedStore(
+    (state) => state.selectedTheater
+  );
+  const selectedDate = useScheduleRelatedStore((state) => state.selectedDate);
+  const selectedScreenTime = useScheduleRelatedStore(
+    (state) => state.selectedScreenTime
+  );
+  const selectedSeats = useScheduleRelatedStore((state) => state.selectedSeats);
+  const selectedPeople = useScheduleRelatedStore(
+    (state) => state.selectedPeople
+  );
+  // ------------------------- Access store
+
+  const seatLabels = getSeatSeparately(selectedSeats);
+  const peopleTypes = getPeoplePrices(selectedPeople);
+
+  function handleCancel() {
+    if (confirm("취소하시겠습니까?")) {
+      if (confirm("되돌이킬 수 없습니다.")) {
+        usePaymentRelatedStore.getState().resetState();
+        useScheduleRelatedStore.getState().resetState();
+        alert("취소 되었습니다.");
+        navigate(AppRoutes.HOME);
+      }
+    }
+  }
+
+  useEffect(() => {
+    if(!selectedScreenTime) {
+      alert("스케쥴 먼저 선택하세요.");
+      navigate(AppRoutes.RESERVATION_PAGE, { replace: true });
+    } else if (selectedSeats.length === 0) {
+      alert("좌석 먼저 선택하세요.");
+      navigate(AppRoutes.SEAT_SELECTION_PAGE, { replace: true });
+    } else if (!hasPaid) {
+      alert("결제 먼저 하세요.");
+      navigate(AppRoutes.PAYMENT_PAGE, { replace: true });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="ticket-page">
+      <div className="navbar-wrapper">
+        <Navbar />
+      </div>
+      <div className="ticket-page-main">
+        <div className="ticket-wrapper">
+          <div className="ticket-main-info">
+            <div className="ticket-top">
+              <div className="ticket-title">TICKET</div>
+              <div className="movie-title">
+                {selectedMovie} ({selectedFormat})
+              </div>
+              <div className="grade">
+                {extractGradeValue(selectedGrade)}세이상관람가
+              </div>
+              <div className="theater">{selectedTheater}</div>
+            </div>
+            <div className="ticket-middle">
+              <div className="middle-left">
+                <div className="label-area">상영일</div>
+                <div className="date-area">
+                  {getMonthAndDay(selectedDate)}{" "}
+                  <span>({getWeekday(selectedDate)})</span>
+                </div>
+              </div>
+              <div className="middle-right">
+                <div className="label-area">상영시간</div>
+                <div className="time-area">
+                  {selectedScreenTime?.[0]}
+                  <span>~{selectedScreenTime?.[1]}</span>
+                </div>
+              </div>
+            </div>
+            <div className="ticket-bottom">
+              <div className="label-area">좌석</div>
+              {/* <div className="seat-area">{getSeatDisplay(selectedSeats)}</div> */}
+              <div className="seat-area">
+                {seatLabels.map((seat, index) => (
+                  <span key={index} className="seat-tag">
+                    {seat}
+                  </span>
+                ))}
+              </div>
+              <div className="people">
+                {peopleTypes.map((people, index) => (
+                  <span className="person" key={index}>
+                    {people.label}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+          <div className="payment-info-area">
+            <div className="payment-amount">
+              <div className="label-area">결제금액</div>
+              <span>{paymentAmount.toLocaleString()}원</span>
+            </div>
+            <div className="payment-method">
+              <div className="label-area">결제수단</div>
+              <span>{getPaymentMethod(payMethod)}</span>
+            </div>
+          </div>
+          <button className="cancel" onClick={() => handleCancel()}>
+            예매취소
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TicketPage;

--- a/src/routes/AppRoutes.ts
+++ b/src/routes/AppRoutes.ts
@@ -9,4 +9,5 @@ export enum AppRoutes {
   RESERVATION_PAGE = "/reservation-page",
   SEAT_SELECTION_PAGE = "/seat-selection-page",
   PAYMENT_PAGE = "/payment-page",
+  TICKET_PAGE = "/ticket-page",
 }

--- a/src/routes/MyRoute.tsx
+++ b/src/routes/MyRoute.tsx
@@ -12,6 +12,7 @@ import SeatSelectionPage from "../pages/SeatSelectionPage/SeatSelectionPage";
 import PaymentPage from "../pages/PaymentPage/PaymentPage";
 import HomePage from "../pages/HomePage/HomePage";
 import ProtectedRoute from "./ProtectedRoute";
+import TicketPage from "../pages/TicketPage/TicketPage";
 
 const MyRoute: React.FC = () => {
   return (
@@ -47,6 +48,14 @@ const MyRoute: React.FC = () => {
           element={
             <ProtectedRoute>
               <PaymentPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path={AppRoutes.TICKET_PAGE}
+          element={
+            <ProtectedRoute>
+              <TicketPage />
             </ProtectedRoute>
           }
         />

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -12,7 +12,7 @@ const ProtectedRoute: React.FC<Props> = ({ children }) => {
   const location = useLocation();
 
   if(!isValid) {
-    alert("Please login first.");
+    alert("로그인 먼저해주세요.");
   }
 
   return !isValid ? (

--- a/src/stores/CinemaRelatedStore.ts
+++ b/src/stores/CinemaRelatedStore.ts
@@ -41,14 +41,12 @@ type CinemaRelatedStore = {
   theaterList: TheaterInfo[];
   setTheaterList: (list: TheaterInfo[]) => void;
 
-  isLogin: boolean;
-  setIsLogin: (login: boolean) => void;
 };
 
 export const useCinemaRelatedStore = create<CinemaRelatedStore>()(
   persist(
     (set) => ({
-      scheduleViewType: "theater",
+      scheduleViewType: "movie",
       setScheduleViewType: (viewType) => set({ scheduleViewType: viewType }),
 
       movieList: [],
@@ -57,15 +55,12 @@ export const useCinemaRelatedStore = create<CinemaRelatedStore>()(
       theaterList: [],
       setTheaterList: (list) => set({ theaterList: list }),
 
-      isLogin: false,
-      setIsLogin: (login) => set({ isLogin: login }),
     }),
     {
       name: "cinema-storage",
       partialize: (state) => ({
         movieList: state.movieList,
         theaterList: state.theaterList,
-        isLogin: state.isLogin,
       }),
     }
   )

--- a/src/stores/PaymentRelatedStore.ts
+++ b/src/stores/PaymentRelatedStore.ts
@@ -1,0 +1,45 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type PaymentRelatedStore = {
+  hasPaid: boolean;
+  setHasPaid: (paid: boolean) => void;
+
+  payMethod: string | null;
+  setPayMethod: (method: string) => void;
+
+  paymentAmount: number;
+  setPaymentAmount: (amount: number) => void;
+
+  resetState: () => void;
+};
+
+export const usePaymentRelatedStore = create<PaymentRelatedStore>()(
+  persist(
+    (set) => ({
+      hasPaid: false,
+      setHasPaid: (paid) => set({ hasPaid: paid }),
+
+      payMethod: null,
+      setPayMethod: (method) => set({ payMethod: method }),
+
+      paymentAmount: 0,
+      setPaymentAmount: (amount) => set({ paymentAmount: amount }),
+
+      resetState: () =>
+        set(() => ({
+          hasPaid: false,
+          payMethod: null,
+          paymentAmount: 0,
+        })),
+    }),
+    {
+      name: "payment-storage",
+      partialize: (state) => ({
+        hasPaid: state.hasPaid,
+        payMethod: state.payMethod,
+        paymentAmount: state.paymentAmount,
+      }),
+    }
+  )
+);

--- a/src/stores/ScheduleRelatedStore.ts
+++ b/src/stores/ScheduleRelatedStore.ts
@@ -37,9 +37,6 @@ type ScheduleRelatedStore = {
   selectedSeats: number[][];
   setSelectedSeats: (seats: number[][]) => void;
 
-  hasPaid: boolean;
-  setHasPaid: (paid: boolean) => void;
-
   resetState: () => void;
 };
 
@@ -80,9 +77,6 @@ export const useScheduleRelatedStore = create<ScheduleRelatedStore>()(
       selectedSeats: [],
       setSelectedSeats: (seats) => set({ selectedSeats: seats }),
 
-      hasPaid: false,
-      setHasPaid: (paid) => set({ hasPaid: paid }),
-
 
       resetState: () =>
         set(() => ({
@@ -101,7 +95,6 @@ export const useScheduleRelatedStore = create<ScheduleRelatedStore>()(
             disabled: 0,
           },
           selectedSeats: [],
-          hasPaid: false,
         })),
     }),
     {
@@ -115,7 +108,6 @@ export const useScheduleRelatedStore = create<ScheduleRelatedStore>()(
         selectedScreenTime: state.selectedScreenTime,
         selectedPeople: state.selectedPeople,
         selectedSeats: state.selectedSeats,
-        hasPaid: state.hasPaid,
       }),
     }
   )

--- a/src/utils/paymentUtils.ts
+++ b/src/utils/paymentUtils.ts
@@ -21,6 +21,14 @@ export const getSeatDisplay = (seats: number[][]): string => {
     .join(", ");
 };
 
+export const getSeatSeparately= (seats: number[][]): string[] => {
+  const getRowLabel = (row: number) => String.fromCharCode(64 + row); // 1 -> A, 2 -> B ...
+
+    return [...seats]
+    .sort((a, b) => a[0] - b[0] || a[1] - b[1]) // sort by row, then col
+    .map(([row, col]) => `${getRowLabel(row)}${col}`);
+};
+
 // 각 인원별 가격 리스트 계산
 export const getPeoplePrices = (people: PeopleCount) => {
   return Object.entries(people)
@@ -36,3 +44,15 @@ export const getTotalPrice = (people: PeopleCount): number => {
   const prices = getPeoplePrices(people);
   return prices.reduce((sum, p) => sum + p.price, 0);
 };
+
+export const getPaymentMethod = (method:string | null) => {
+  if(method == "card") {
+    return "신용/체크카드";
+  } else if(method == "easy") {
+    return "간편결제";
+  } else if(method == "phone") {
+    return "휴대폰 결제";
+  } else {
+    return "알 수 없음";
+  }
+}

--- a/src/utils/scheduleRelatedUtils.ts
+++ b/src/utils/scheduleRelatedUtils.ts
@@ -97,7 +97,15 @@ export function getWeekday(dateStr: string) {
   return weekday;
 }
 
-export const extractGradeValue = (grade: string | undefined): string => {
+export function getMonthAndDay(dateStr: string) {
+  const date = new Date(dateStr);
+
+const month = String(date.getMonth() + 1).padStart(2, "0"); // "06"
+const day = String(date.getDate()).padStart(2, "0");        // "03"
+  return `${month}/${day}`;
+}
+
+export const extractGradeValue = (grade: string | undefined | null): string => {
   const matched = grade?.match(/\d+/)?.[0];
   return matched || "all";
 };


### PR DESCRIPTION
## 좌석 선택 페이지 (Seat Selection Page)

### Route
- When a user selects a payment method and clicks the "결제하기" button on the Payment Page, the app navigates to the **티켓 페이지 (Ticket Page)**.

### Features
- Users must complete all required steps (select schedule, seat, and payment method) to access the Ticket Page.
  - If the user cancels the reservation from the Ticket Page, they are redirected back to the **Homepage**.


---

## General Updates

- Updated navigation logic on **SeatSelectionPage** and **PaymentPage**:
  - If a logged-in user tries to access the PaymentPage or SeatSelectionPage directly via URL **without selecting a schedule**, they are redirected to the **ReservationPage**.
  - If a user tries to access the PaymentPage **without selecting a seat**, they are redirected to the **SeatSelectionPage**.
- Fixed minor logic issues and removed unnecessary code for better clarity and performance.

---

## Future Improvements

- Improve overall UI styling (e.g., colors, spacing, responsive layout).
- Save reservation data to display later in **My Page > 예매내역 (Reservation History)**.

---

### Screenshot

- 티켓 (Ticket Page) 

![image](https://github.com/user-attachments/assets/139efba1-367d-43f3-918e-d72cd0185e62)

